### PR TITLE
Updated README to suggest docker-compose usage, first

### DIFF
--- a/docker/run_conda3/README.md
+++ b/docker/run_conda3/README.md
@@ -4,13 +4,36 @@ Easily run a Jupyter notebook in Python 3, with all the RDKit dependencies and p
 
 ## Instructions
 
-1. Install [Docker](https://www.docker.com/community-edition).
+1. Install [Docker](https://www.docker.com/community-edition) and [docker-compose](https://docs.docker.com/compose/install/).
 2. Clone this repo.
-3. Build docker image from Dockerfile:
+3. Build docker image from Dockerfile, using `docker-compose`:
+
+
+```bash
+docker-compose build
+```
+4. Run container: 
+
+```bash
+# start container with logs output to terminal
+docker-compose up
+
+# or start container in background
+docker-compose up -d
+
+# output the container logs
+docker-compose logs -f
+```
+-----
+
+### Alternatively 
+
+You can use regular docker:
 
 ```bash
 docker build -t run_rdkit_conda .
 ```
+
 
 4. Run the docker container:
 
@@ -52,26 +75,3 @@ from IPython.display import Image
 ### Caveats
 If you are running any other processes on port 8888 (e.g. another Jupyter notebook) then you will likely have problems connecting to the containerized notebook in the browser. I recommend shutting down any other Jupyter notebooks first, before running `docker run`.
 
-Docker Compose
-===
-
-Once steps 1 and 2 of the [Instuctions](#instructions) sections have been
-completed you can use docker-compose to complete steps 3-7:
-
-Step 3:
-
-```bash
-docker-compose build
-```
-
-Step 4-7:
-```bash
-# start container with logs output to terminal
-docker-compose up
-
-# or start container in background
-docker-compose up -d
-
-# output the container logs
-docker-compose logs -f
-```

--- a/docker/run_conda3/README.md
+++ b/docker/run_conda3/README.md
@@ -38,7 +38,11 @@ docker build -t run_rdkit_conda .
 4. Run the docker container:
 
 ```bash
-docker run -d -p 8888:8888 -t run_rdkit_conda /bin/bash -c "jupyter notebook --notebook-dir=/tmp --ip=* --allow-root"
+# run container in the background
+docker run -d -p 8888:8888 -t run_rdkit_conda 
+
+# run container in the foreground
+docker run -it -p 8888:8888 -t run_rdkit_conda
 ```
 
 5. Docker will return a container ID, type `docker logs <id>` passing in the first three characters from the id.


### PR DESCRIPTION
Hi @Deric4, 

I've noticed our vanilla docker workflow is not working anymore, I'm not sure if the issue resides with Jupyter or Docker (our Dockerfile), but your `docker-compose` implementation seems to work every time with no issues. I've also spoke to colleges who have been using this git repo for their work, and they are all running the `docker-compose` route. I've bumped those instructions to the top of the document. 

Let me know what you think. 